### PR TITLE
Improve action manifest and default bindings

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -15,7 +15,6 @@
 	], 
 	
 	"actions": [
-
 		{
 			"name": "/actions/base/in/pose_lefthand",
 			"type": "pose"
@@ -31,6 +30,16 @@
 		{
 			"name": "/actions/base/out/vibration_right",
 			"type": "vibration"
+		},
+		{
+			"name" : "/actions/base/in/skeleton_lefthand",
+			"skeleton" : "/skeleton/hand/left",
+			"type" : "skeleton"
+		},
+		{
+			"name" : "/actions/base/in/skeleton_righthand",
+			"skeleton" : "/skeleton/hand/right",
+			"type" : "skeleton"
 		},
 		{
 			"name": "/actions/main/in/PrimaryAttack",
@@ -110,7 +119,8 @@
 		},
 		{
 			"name": "/actions/main/in/Spray",
-			"type": "boolean"
+			"type": "boolean",
+			"requirement": "optional"
 		},
 		{
 			"name": "/actions/main/in/Scoreboard",
@@ -118,7 +128,8 @@
 		},
 		{
 			"name": "/actions/main/in/ShowHUD",
-			"type": "boolean"
+			"type": "boolean",
+			"requirement": "optional"
 		},
 		{
 			"name": "/actions/main/in/Pause",
@@ -130,13 +141,40 @@
 		{
 			"name": "/actions/main",
 			"usage": "leftright"
+		},
+		{
+		  "name": "/actions/base",
+		  "usage": "hidden"
 		}
 	],
 
 	"localization" : [
 		{
 			"language_tag": "en_us",
-			"/actions/main" : "Main"
+			"/actions/main" : "Main",
+			"/actions/main/in/PrimaryAttack" : "Primary Attack",
+			"/actions/main/in/SecondaryAttack" : "Secondary Attack",
+			"/actions/main/in/Jump" : "Jump",
+			"/actions/main/in/Walk" : "Walk",
+			"/actions/main/in/Turn" : "Turn",
+			"/actions/main/in/Reload" : "Reload",
+			"/actions/main/in/Use" : "Use",
+			"/actions/main/in/NextItem" : "Next Item",
+			"/actions/main/in/PrevItem" : "Previous Item",
+			"/actions/main/in/ResetPosition" : "Reset Position",
+			"/actions/main/in/Crouch" : "Crouch",
+			"/actions/main/in/Flashlight" : "Flashlight",
+			"/actions/main/in/ActivateVR" : "Activate VR",
+			"/actions/main/in/MenuSelect" : "Menu Select",
+			"/actions/main/in/MenuBack" : "Menu Back",
+			"/actions/main/in/MenuUp" : "Menu Up",
+			"/actions/main/in/MenuDown" : "Menu Down",
+			"/actions/main/in/MenuLeft" : "Menu Left",
+			"/actions/main/in/MenuRight" : "Menu Right",
+			"/actions/main/in/Spray" : "Spray",
+			"/actions/main/in/Scoreboard" : "Show Scoreboard",
+			"/actions/main/in/ShowHUD" : "Show HUD",
+			"/actions/main/in/Pause" : "Pause"
 		}
 	]
 }

--- a/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
@@ -185,27 +185,11 @@
 			{
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/main/in/Spray"
-                  }
-               },
-               "mode" : "button",
-            },
-			{
-               "inputs" : {
-                  "click" : {
                      "output" : "/actions/main/in/Scoreboard"
                   }
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/a"
-            },
-			{
-               "inputs" : {
-                  "click" : {
-                     "output" : "/actions/main/in/ShowHUD"
-                  }
-               },
-               "mode" : "button"
             },
 			{
                "inputs" : {

--- a/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
@@ -180,27 +180,11 @@
 			{
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/main/in/Spray"
-                  }
-               },
-               "mode" : "button"
-            },
-			{
-               "inputs" : {
-                  "click" : {
                      "output" : "/actions/main/in/Scoreboard"
                   }
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/x"
-            },
-			{
-               "inputs" : {
-                  "click" : {
-                     "output" : "/actions/main/in/ShowHUD"
-                  }
-               },
-               "mode" : "button"
             },
 			{
                "inputs" : {

--- a/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
@@ -180,27 +180,11 @@
 			{
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/main/in/Spray"
-                  }
-               },
-               "mode" : "button"
-            },
-			{
-               "inputs" : {
-                  "click" : {
                      "output" : "/actions/main/in/Scoreboard"
                   }
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/x"
-            },
-			{
-               "inputs" : {
-                  "click" : {
-                     "output" : "/actions/main/in/ShowHUD"
-                  }
-               },
-               "mode" : "button"
             },
 			{
                "inputs" : {


### PR DESCRIPTION
Various improvements to action manifest and default bindings

- Add skeleton action
  SteamVR was logging errors about the skeleton being bound in default bindings but the action not existing. As far as I can tell, skeletal data isn't used by the mod (yet?) so an alternative to this would be remove the action from the bindings instead.
  
- Mark actions not bound by default as optional
  With the removal of the unbound actions as mentioned below, the binding UI will point out the Spray and Show Scoreboard actions as suggested to be bound. This is subjective, but I feel like they're not essential and are fine to be marked as optional.

- Hide base action set in binding UI
  There are no user bindable actions in this set, so hiding it seems like a good option.

- Add localization strings for actions
  Unlocalized names are stripped of their captilization in the binding UI. This adds them back and puts some spaces where appropriate.

- Remove unbound actions without device path from default bindings. This confuses SteamVR and breaks the binding UI when trying to create chords.
  The main reason I started poking things here. Unbound actions should not be present in the default binding files. SteamVR logs errors for this and it wouldn't matter much of course... but it breaks the binding UI for the SteamVR session when attempting to create chords, so that's not great.
  
  
No idea how open to pull requests you are, but I was thinking looking into overlay parts of the code as well, as I have some experience there. Seeing some potential improvements.
Can't be much help with the actual modding of the game though.