### PR TITLE
Use the same tracking space as WaitGetPoses() for overlay transforms

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -270,7 +270,7 @@ void VR::RepositionOverlays()
         0.0f, 0.0f, 1.0f, 1.0f
     };
 
-    vr::ETrackingUniverseOrigin trackingOrigin = vr::ETrackingUniverseOrigin::TrackingUniverseSeated;
+    vr::ETrackingUniverseOrigin trackingOrigin = vr::VRCompositor()->GetTrackingSpace();
 
     // Reposition main menu overlay
     float renderWidth = m_VKBackBuffer.m_VulkanData.m_nWidth;


### PR DESCRIPTION
This changes the tracking universe used to set the overlay transforms to be the same as the one used by WaitGetPoses().
As the poses originate from that function, we can't just assume it's always the seated universe.

This should fix issue #66.