### PR TITLE
Use mouse scale on overlays

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -82,6 +82,15 @@ VR::VR(Game *game)
     m_Overlay->SetOverlayInputMethod(m_MainMenuHandle, vr::VROverlayInputMethod_Mouse);
     m_Overlay->SetOverlayInputMethod(m_HUDHandle, vr::VROverlayInputMethod_Mouse);
 
+    int windowWidth, windowHeight;
+    m_Game->m_MaterialSystem->GetRenderContext()->GetWindowSize(windowWidth, windowHeight);
+
+    const vr::HmdVector2_t mouseScaleHUD = {windowWidth, windowHeight};
+    m_Overlay->SetOverlayMouseScale(m_HUDHandle, &mouseScaleHUD);
+
+    const vr::HmdVector2_t mouseScaleMenu = {m_RenderWidth, m_RenderHeight};
+    m_Overlay->SetOverlayMouseScale(m_MainMenuHandle, &mouseScaleMenu);
+
     UpdatePosesAndActions();
 
     m_IsInitialized = true;
@@ -414,17 +423,15 @@ void VR::ProcessMenuInput()
 
                 if (currentOverlay == m_HUDHandle)
                 {
-                    // The pause menu aspect ratio can vary, but the overlay aspect ratio is always 1:1, so correct the pointer
-                    float lowerOverlayBound = (1 - ((float)windowHeight / (float)windowWidth)) / 2.0;
-                    float upperOverlayBound = 1 - lowerOverlayBound;
-                    float laserYcorrected = (laserY - lowerOverlayBound) / (upperOverlayBound - lowerOverlayBound);
-                    laserYcorrected = std::clamp(laserYcorrected, 0.0f, 1.0f);
-                    m_Game->m_VguiInput->SetCursorPos(windowWidth * laserX, windowHeight * (1 - laserYcorrected));
+                    laserY = -laserY + windowHeight;
                 }
-                else // main menu
+                else // main menu (uses render sized texture)
                 {
-                    m_Game->m_VguiInput->SetCursorPos(windowWidth * laserX, windowHeight * (1 - laserY));
+                    laserX = (laserX / m_RenderWidth) * windowWidth;
+                    laserY = ((-laserY + m_RenderHeight) / m_RenderHeight) * windowHeight;
                 }
+
+                m_Game->m_VguiInput->SetCursorPos(laserX, laserY);
                 break;
             }
 


### PR DESCRIPTION
SteamVR only cares about the aspect ratio of the mouse scale for laser pointer hit-testing, so setting it to the actual texture resolution of the overlays improves the accuracy of those inputs.
Also simplifies event handling, though the menu and HUD overlays come in different resolutions & aspect ratios so they have to be handled separately still.

On a side note, I'm not a exactly fan of how laser pointer interaction is toggled (the angles not being updated without active player entity is one thing), but I see code trying to do it via ComputeOverlayIntersection() in the commit history already. Were there big issues with it? I can see the controller tip matrix not being used and the inaccurate overlay input creating issues there, but that would be solvable.
I've written code for that before for Desktop+ and it works well, but before I throw that together I thought I might as well ask first.