### PR TITLE
Add scroll inputs to overlays

### DIFF
--- a/L4D2VR/sdk/sdk.h
+++ b/L4D2VR/sdk/sdk.h
@@ -1929,7 +1929,7 @@ public:
 	virtual void InternalMousePressed(ButtonCode_t);
 	virtual void InternalMouseDoublePressed(ButtonCode_t);
 	virtual void InternalMouseReleased(ButtonCode_t);
-	virtual void InternalMouseWheeled(void);
+	virtual void InternalMouseWheeled(int);
 	virtual void InternalKeyCodePressed(KeyCode);
 	virtual void InternalKeyCodeTyped(KeyCode code);
 	virtual void InternalKeyTyped(void);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -81,6 +81,8 @@ VR::VR(Game *game)
     m_Overlay->CreateOverlay("HUDOverlayKey", "HUDOverlay", &m_HUDHandle);
     m_Overlay->SetOverlayInputMethod(m_MainMenuHandle, vr::VROverlayInputMethod_Mouse);
     m_Overlay->SetOverlayInputMethod(m_HUDHandle, vr::VROverlayInputMethod_Mouse);
+    m_Overlay->SetOverlayFlag(m_MainMenuHandle, vr::VROverlayFlags_SendVRDiscreteScrollEvents, true);
+    m_Overlay->SetOverlayFlag(m_HUDHandle, vr::VROverlayFlags_SendVRDiscreteScrollEvents, true);
 
     UpdatePosesAndActions();
 
@@ -439,6 +441,10 @@ void VR::ProcessMenuInput()
                 if (currentOverlay == m_HUDHandle)
                     m_Game->m_VguiInput->InternalMousePressed(ButtonCode_t::MOUSE_LEFT);
                 m_Game->m_VguiInput->InternalMouseReleased(ButtonCode_t::MOUSE_LEFT);
+                break;
+
+            case vr::VREvent_ScrollDiscrete:
+                m_Game->m_VguiInput->InternalMouseWheeled((int)vrEvent.data.scroll.ydelta);
                 break;
             }
         }


### PR DESCRIPTION
This adds mouse wheel scroll input to the overlays. Seemed simple enough and is useful when trying to go through that addons list.