### PR TITLE
Activate laser pointer when controller is pointing the at the overlay using the tip matrix

### DIFF
--- a/L4D2VR/sdk/vector.h
+++ b/L4D2VR/sdk/vector.h
@@ -404,13 +404,24 @@ class VMatrix
 {
 public:
 
-	VMatrix();
+	VMatrix()
+	{
+	}
+
 	VMatrix(
 		vec_t m00, vec_t m01, vec_t m02, vec_t m03,
 		vec_t m10, vec_t m11, vec_t m12, vec_t m13,
 		vec_t m20, vec_t m21, vec_t m22, vec_t m23,
 		vec_t m30, vec_t m31, vec_t m32, vec_t m33
-	);
+	)
+	{
+		Init(
+			m00, m01, m02, m03,
+			m10, m11, m12, m13,
+			m20, m21, m22, m23,
+			m30, m31, m32, m33
+		);
+	}
 
 	// Creates a matrix where the X axis = forward
 	// the Y axis = left, and the Z axis = up
@@ -426,7 +437,28 @@ public:
 		vec_t m10, vec_t m11, vec_t m12, vec_t m13,
 		vec_t m20, vec_t m21, vec_t m22, vec_t m23,
 		vec_t m30, vec_t m31, vec_t m32, vec_t m33
-	);
+	)
+	{
+		m[0][0] = m00;
+		m[0][1] = m01;
+		m[0][2] = m02;
+		m[0][3] = m03;
+
+		m[1][0] = m10;
+		m[1][1] = m11;
+		m[1][2] = m12;
+		m[1][3] = m13;
+
+		m[2][0] = m20;
+		m[2][1] = m21;
+		m[2][2] = m22;
+		m[2][3] = m23;
+
+		m[3][0] = m30;
+		m[3][1] = m31;
+		m[3][2] = m32;
+		m[3][3] = m33;
+	}
 
 
 	// Initialize from a 3x4
@@ -529,7 +561,30 @@ public:
 	VMatrix &operator=(const VMatrix &mOther);
 
 	// Multiply two matrices (out = this * vm).
-	void		MatrixMul(const VMatrix &vm, VMatrix &out) const;
+	void		MatrixMul(const VMatrix &vm, VMatrix &out) const
+	{
+		out.Init(
+			m[0][0]*vm.m[0][0] + m[0][1]*vm.m[1][0] + m[0][2]*vm.m[2][0] + m[0][3]*vm.m[3][0],
+			m[0][0]*vm.m[0][1] + m[0][1]*vm.m[1][1] + m[0][2]*vm.m[2][1] + m[0][3]*vm.m[3][1],
+			m[0][0]*vm.m[0][2] + m[0][1]*vm.m[1][2] + m[0][2]*vm.m[2][2] + m[0][3]*vm.m[3][2],
+			m[0][0]*vm.m[0][3] + m[0][1]*vm.m[1][3] + m[0][2]*vm.m[2][3] + m[0][3]*vm.m[3][3],
+
+			m[1][0]*vm.m[0][0] + m[1][1]*vm.m[1][0] + m[1][2]*vm.m[2][0] + m[1][3]*vm.m[3][0],
+			m[1][0]*vm.m[0][1] + m[1][1]*vm.m[1][1] + m[1][2]*vm.m[2][1] + m[1][3]*vm.m[3][1],
+			m[1][0]*vm.m[0][2] + m[1][1]*vm.m[1][2] + m[1][2]*vm.m[2][2] + m[1][3]*vm.m[3][2],
+			m[1][0]*vm.m[0][3] + m[1][1]*vm.m[1][3] + m[1][2]*vm.m[2][3] + m[1][3]*vm.m[3][3],
+
+			m[2][0]*vm.m[0][0] + m[2][1]*vm.m[1][0] + m[2][2]*vm.m[2][0] + m[2][3]*vm.m[3][0],
+			m[2][0]*vm.m[0][1] + m[2][1]*vm.m[1][1] + m[2][2]*vm.m[2][1] + m[2][3]*vm.m[3][1],
+			m[2][0]*vm.m[0][2] + m[2][1]*vm.m[1][2] + m[2][2]*vm.m[2][2] + m[2][3]*vm.m[3][2],
+			m[2][0]*vm.m[0][3] + m[2][1]*vm.m[1][3] + m[2][2]*vm.m[2][3] + m[2][3]*vm.m[3][3],
+
+			m[3][0]*vm.m[0][0] + m[3][1]*vm.m[1][0] + m[3][2]*vm.m[2][0] + m[3][3]*vm.m[3][0],
+			m[3][0]*vm.m[0][1] + m[3][1]*vm.m[1][1] + m[3][2]*vm.m[2][1] + m[3][3]*vm.m[3][1],
+			m[3][0]*vm.m[0][2] + m[3][1]*vm.m[1][2] + m[3][2]*vm.m[2][2] + m[3][3]*vm.m[3][2],
+			m[3][0]*vm.m[0][3] + m[3][1]*vm.m[1][3] + m[3][2]*vm.m[2][3] + m[3][3]*vm.m[3][3]
+		);
+	}
 
 	// Add two matrices.
 	const VMatrix &operator+=(const VMatrix &other);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -720,7 +720,7 @@ void VR::ProcessInput()
     }
 }
 
-VMatrix VR::VMatrixToHmdMatrix(const vr::HmdMatrix34_t &hmdMat)
+VMatrix VR::VMatrixFromHmdMatrix(const vr::HmdMatrix34_t &hmdMat)
 {
     // VMatrix has a different implicit coordinate system than HmdMatrix34_t, but this function does not convert between them
     VMatrix vMat(
@@ -733,7 +733,7 @@ VMatrix VR::VMatrixToHmdMatrix(const vr::HmdMatrix34_t &hmdMat)
     return vMat;
 }
 
-vr::HmdMatrix34_t VR::VMatrixFromHmdMatrix(const VMatrix &vMat)
+vr::HmdMatrix34_t VR::VMatrixToHmdMatrix(const VMatrix &vMat)
 {
     vr::HmdMatrix34_t hmdMat = {0};
 
@@ -808,8 +808,8 @@ bool VR::CheckOverlayIntersectionForController(vr::VROverlayHandle_t overlayHand
     if (!controllerPose.bPoseIsValid)
         return false;
 
-    VMatrix controllerVMatrix = VMatrixToHmdMatrix(controllerPose.mDeviceToAbsoluteTracking);
-    VMatrix tipVMatrix        = VMatrixToHmdMatrix(GetControllerTipMatrix(controllerRole));
+    VMatrix controllerVMatrix = VMatrixFromHmdMatrix(controllerPose.mDeviceToAbsoluteTracking);
+    VMatrix tipVMatrix        = VMatrixFromHmdMatrix(GetControllerTipMatrix(controllerRole));
     tipVMatrix.MatrixMul(controllerVMatrix, controllerVMatrix);
 
     vr::VROverlayIntersectionParams_t  params  = {0};

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -196,8 +196,8 @@ public:
 	void GetViewParameters();
 	void ProcessMenuInput();
 	void ProcessInput();
-	VMatrix VMatrixToHmdMatrix(const vr::HmdMatrix34_t &hmdMat);
-	vr::HmdMatrix34_t VMatrixFromHmdMatrix(const VMatrix &vMat);
+	VMatrix VMatrixFromHmdMatrix(const vr::HmdMatrix34_t &hmdMat);
+	vr::HmdMatrix34_t VMatrixToHmdMatrix(const VMatrix &vMat);
 	vr::HmdMatrix34_t GetControllerTipMatrix(vr::ETrackedControllerRole controllerRole);
 	bool CheckOverlayIntersectionForController(vr::VROverlayHandle_t overlayHandle, vr::ETrackedControllerRole controllerRole);
 	QAngle GetRightControllerAbsAngle();

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -196,6 +196,10 @@ public:
 	void GetViewParameters();
 	void ProcessMenuInput();
 	void ProcessInput();
+	VMatrix VMatrixToHmdMatrix(const vr::HmdMatrix34_t &hmdMat);
+	vr::HmdMatrix34_t VMatrixFromHmdMatrix(const VMatrix &vMat);
+	vr::HmdMatrix34_t GetControllerTipMatrix(vr::ETrackedControllerRole controllerRole);
+	bool CheckOverlayIntersectionForController(vr::VROverlayHandle_t overlayHandle, vr::ETrackedControllerRole controllerRole);
 	QAngle GetRightControllerAbsAngle();
 	Vector GetRightControllerAbsPos();
 	Vector GetRecommendedViewmodelAbsPos();


### PR DESCRIPTION
As previously mentioned, here's what I believe to be an improvement to the current laser pointer toggle behavior.
I've opted into using the VMatrix class for the one matrix multiplication and pulled some more SDK bits in. But only as much as needed for this.

This is probably gonna be the last pull request from me for now. I'll keep an eye on the project, though.