### PR TITLE
Add support for multisample antialiasing (based on Portal 2 VR fork)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dxvk"]
 	path = dxvk
-	url = https://github.com/sd805/dxvk.git
-	branch = dxvk-async
+	url = https://github.com/fholger/dxvk_l4d2vr.git
+	branch = msaa

--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -8,3 +8,4 @@ HideArms=false
 HudDistance=1.3
 HudSize=1.1
 HudAlwaysVisible=false
+AntiAliasing=0

--- a/L4D2VR/l4d2vr.vcxproj
+++ b/L4D2VR/l4d2vr.vcxproj
@@ -154,6 +154,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,6 +173,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>C:\Dev\infra\openvr\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -42,6 +42,7 @@ VR::VR(Game *game)
     m_System = vr::OpenVRInternal_ModuleContext().VRSystem();
 
     m_System->GetRecommendedRenderTargetSize(&m_RenderWidth, &m_RenderHeight);
+    m_AntiAliasing = 0;
 
     float l_left = 0.0f, l_right = 0.0f, l_top = 0.0f, l_bottom = 0.0f;
     m_System->GetProjectionRaw(vr::EVREye::Eye_Left, &l_left, &l_right, &l_top, &l_bottom);
@@ -190,10 +191,10 @@ void VR::CreateVRTextures()
     m_Game->m_MaterialSystem->isGameRunning = true;
 
     m_CreatingTextureID = Texture_LeftEye;
-    m_LeftEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("leftEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
+    m_LeftEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("leftEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
     
     m_CreatingTextureID = Texture_RightEye;
-    m_RightEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("rightEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
+    m_RightEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("rightEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
     
     m_CreatingTextureID = Texture_HUD;
     m_HUDTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("vrHUD", windowWidth, windowHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
@@ -1056,6 +1057,7 @@ void VR::ParseConfigFile()
     m_HudDistance = std::stof(userConfig["HudDistance"]);
     m_HudSize = std::stof(userConfig["HudSize"]);
     m_HudAlwaysVisible = userConfig["HudAlwaysVisible"] == "true";
+    m_AntiAliasing = std::stol(userConfig["AntiAliasing"]);
 }
 
 void VR::WaitForConfigUpdate()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -46,6 +46,7 @@ public:
 
 	uint32_t m_RenderWidth;
 	uint32_t m_RenderHeight;
+	uint32_t m_AntiAliasing;
 	float m_Aspect;
 	float m_Fov;
 


### PR DESCRIPTION
This simply cherry-picks commit 42bb8f4b706de0a0336f4679f43241556f12ccf3 from Portal 2 VR that adds support for multisample AA. It seems to work fine in-game with no new graphical issues. 

Note that this does change the dxvk submodule to point to fholger's fork as per the original commit. And to use MSAA, you need to enable it from the config.txt!
