### PR TITLE
Fix distorted rendering on PSVR2.

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -42,30 +42,41 @@ VR::VR(Game *game)
     m_System = vr::OpenVRInternal_ModuleContext().VRSystem();
 
     m_System->GetRecommendedRenderTargetSize(&m_RenderWidth, &m_RenderHeight);
-
+    
     float l_left = 0.0f, l_right = 0.0f, l_top = 0.0f, l_bottom = 0.0f;
     m_System->GetProjectionRaw(vr::EVREye::Eye_Left, &l_left, &l_right, &l_top, &l_bottom);
 
     float r_left = 0.0f, r_right = 0.0f, r_top = 0.0f, r_bottom = 0.0f;
     m_System->GetProjectionRaw(vr::EVREye::Eye_Right, &r_left, &r_right, &r_top, &r_bottom);
 
-    float tanHalfFov[2];
 
-    tanHalfFov[0] = std::max({ -l_left, l_right, -r_left, r_right });
-    tanHalfFov[1] = std::max({ -l_top, l_bottom, -r_top, r_bottom });
+    if (m_RenderHeight > 0) {
+        m_Aspect = (float)m_RenderWidth / (float)m_RenderHeight;
+    }
+    else {
+        m_Aspect = 1.0f;
+    }
 
-    m_TextureBounds[0].uMin = 0.5f + 0.5f * l_left / tanHalfFov[0];
-    m_TextureBounds[0].uMax = 0.5f + 0.5f * l_right / tanHalfFov[0];
-    m_TextureBounds[0].vMin = 0.5f - 0.5f * l_bottom / tanHalfFov[1];
-    m_TextureBounds[0].vMax = 0.5f - 0.5f * l_top / tanHalfFov[1];
+    float tanHalfFovH = std::max({ -l_left, l_right, -r_left, r_right });
+    float tanHalfFovV = std::max({ -l_top, l_bottom, -r_top, r_bottom });
 
-    m_TextureBounds[1].uMin = 0.5f + 0.5f * r_left / tanHalfFov[0];
-    m_TextureBounds[1].uMax = 0.5f + 0.5f * r_right / tanHalfFov[0];
-    m_TextureBounds[1].vMin = 0.5f - 0.5f * r_bottom / tanHalfFov[1];
-    m_TextureBounds[1].vMax = 0.5f - 0.5f * r_top / tanHalfFov[1];
+    // For some headsets, the driver provided texture size doesn't match the geometric aspect ratio of the lenses.
+    // In this case, we need to adjust the vertical tangent while still rendering to the recommended RT size. 
 
-    m_Aspect = tanHalfFov[0] / tanHalfFov[1];
-    m_Fov = 2.0f * atan(tanHalfFov[0]) * 360 / (3.14159265358979323846 * 2);
+    float idealAspect = tanHalfFovH / tanHalfFovV;
+    float adjustedTanHalfFovV = tanHalfFovH / m_Aspect;
+
+    m_Fov = 2.0f * atan(tanHalfFovH) * 360 / (3.14159265358979323846 * 2);
+
+    m_TextureBounds[0].uMin = 0.5f + 0.5f * l_left / tanHalfFovH;
+    m_TextureBounds[0].uMax = 0.5f + 0.5f * l_right / tanHalfFovH;
+    m_TextureBounds[0].vMin = 0.5f - 0.5f * l_bottom / adjustedTanHalfFovV;
+    m_TextureBounds[0].vMax = 0.5f - 0.5f * l_top / adjustedTanHalfFovV;
+
+    m_TextureBounds[1].uMin = 0.5f + 0.5f * r_left / tanHalfFovH;
+    m_TextureBounds[1].uMax = 0.5f + 0.5f * r_right / tanHalfFovH;
+    m_TextureBounds[1].vMin = 0.5f - 0.5f * r_bottom / adjustedTanHalfFovV;
+    m_TextureBounds[1].vMax = 0.5f - 0.5f * r_top / adjustedTanHalfFovV;
 
     InstallApplicationManifest("manifest.vrmanifest");
     SetActionManifest("action_manifest.json");


### PR DESCRIPTION
I spent a while debugging and testing this and it seems to work fine, but I can't test on other headsets and I am also not super familiar with OpenVR. 

Essentially, on PSVR2, rendering is incorrect using the raw values provided by the driver. This is only a little uncomfortable to look at, and is mainly noticeable on weapons. 
Originally, I thought the issue was that the viewmodels weren't being transformed correctly due to some quirk of the PSVR2 controller position, but it turns out the whole view is stretched vertically. You can see it in screenshots.

<img width="1765" height="1765" alt="L4D2, PSVR2, before change" src="https://github.com/user-attachments/assets/c1075002-4747-4008-8d10-0e0a2a40840d" />

With this change, there is no stretching. 

<img width="1781" height="1781" alt="L4D2, PSVR2, after change" src="https://github.com/user-attachments/assets/df577f0a-cd09-4b51-839e-e2a2c7b05011" />

This change adjusts the vertical tangent to match the aspect ratio of the render texture. Changing the render texture size also works, but breaks post-effects like the pause menu blur. 
